### PR TITLE
Fix for 4 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "phantomjs": "1.9.16",
     "plus.application": "~1.0.7",
     "plus.garden.selenium-standalone": "2.46.0",
-    "request": "2.34.0",
+    "request": "2.74.0",
     "selenium-webdriver": "2.42.1",
     "sinon": "1.8.2",
     "sizzle": "~2.2.0",


### PR DESCRIPTION
plus.garden currently has a 20 vulnerable dependency paths, introducing 10 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
- [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
- [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
- [Denial of Service (Event Loop Blocking)](https://snyk.io/vuln/npm:qs:20140806-1) vulnerability in the `qs` dependency.
- [Denial of Service (Memory Exhaustion)](https://snyk.io/vuln/npm:qs:20140806) vulnerability in the `qs` dependency.

You can see [Snyk test report](https://snyk.io/test/github/linkshare/plus.garden) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerabilities listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade other dependencies as well.

Stay Secure,
The Snyk Team
